### PR TITLE
Support `merge --squash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ git commit
 git fetch
 git log
 git merge
+git merge-base
 git pull
 git push
 git rebase

--- a/css/explaingit.css
+++ b/css/explaingit.css
@@ -199,8 +199,8 @@ span.cmd {
 }
 
 circle.commit {
-  fill: #CCCCCC;
-  stroke: #888888;
+  fill: hsl(0, 0%, 80%);
+  stroke: hsl(0, 0%, 53%);
   stroke-width: 3;
   transition-property: stroke, fill;
   /* Keep this in sync with `TRANSITION_DURATION_MS` in 'js/historyview.js' */
@@ -236,8 +236,14 @@ circle.commit.cherry-picked.checked-out {
 }
 
 circle.commit.squash-merge {
-  stroke: #2A7A60;
-  fill: #C0FDFB;
+  stroke: hsl(161, 49%, 32%);
+  fill: hsl(178, 94%, 87%);
+}
+
+circle.commit.squash-to-copy {
+  stroke-width: 4;
+  stroke: hsl(161, 100%, 53%);
+  fill: hsl(178, 100%, 80%);
 }
 
 circle.commit.squash-merge.checked-out {

--- a/css/explaingit.css
+++ b/css/explaingit.css
@@ -276,8 +276,9 @@ circle.commit.logging {
 }
 
 .commit-pointer.branchless, .merge-pointer.branchless {
-  stroke: #DDD;
-  stroke-width: 2;
+  stroke: #BBB;
+  stroke-width: 4;
+  stroke-dasharray: 4;
 }
 
 text.id-label {

--- a/css/explaingit.css
+++ b/css/explaingit.css
@@ -235,6 +235,15 @@ circle.commit.cherry-picked.checked-out {
   fill: #ff5151;
 }
 
+circle.commit.squash-merge {
+  stroke: #2A7A60;
+  fill: #C0FDFB;
+}
+
+circle.commit.squash-merge.checked-out {
+  fill: #C0FDFB;
+}
+
 circle.commit.branchless {
   fill: #FEFEFE;
   stroke: #888888;

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             markerWidth="4" markerHeight="3" orient="auto" viewBox="0 0 10 10">
         <path d="M 0 0 L 10 5 L 0 10 z"/>
     </marker>
-    <marker id="faded-triangle" refX="5" refY="5" markerUnits="strokeWidth" fill="#DDD"
+    <marker id="faded-triangle" refX="5" refY="5" markerUnits="strokeWidth" fill="#BBB"
             markerWidth="4" markerHeight="3" orient="auto" viewBox="0 0 10 10">
         <path d="M 0 0 L 10 5 L 0 10 z"/>
     </marker>

--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -676,11 +676,15 @@ function(_yargs, d3, demos) {
 
         if (result === 'Fast-Forward') {
           this.info('You have performed a fast-forward merge.');
+        } else if (result === 'Squash') {
+          this.info('You have performed a squash merge.');
         }
       }, function(before, after) {
         var reflogMsg = "merge " + branch + ": "
         if (result === 'Fast-Forward') {
           reflogMsg += "Fast-forward"
+        } else if (result === 'Squash') {
+          reflogMsg += "Squash"
         } else {
           reflogMsg += "Merge made by the 'recursive' strategy."
         }

--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -641,26 +641,38 @@ function(_yargs, d3, demos) {
 
     merge: function(args) {
       var noFF = false;
-      var branch = args[0];
-      var result
+      var squash = false;
+
+      // Assume first arg is the flag, second is the branch
+      var [flag, branch] = args;
+      var result;
+
+      var validFlags = ['--no-ff', '--ff', '--squash'];
+      var validFlagsStr = validFlags.join(', ');
+
+      if (args.length > 2) {
+        throw new Error(`Too many arguments. This demo only supports the following singular flags: ${validFlagsStr}`);
+      }
+
       if (args.length === 2) {
-        if (args[0] === '--no-ff' || args[0] === '--ff') {
-          if (args[0] === '--no-ff') {
+        if (!flag.startsWith('--')) {
+          // Swap the args, first arg is actually the branch
+          [flag, branch] = [branch, flag];
+        }
+  
+        if (validFlags.includes(flag)) {
+          if (flag === '--no-ff') {
             noFF = true;
+          } else if (flag === '--squash') {
+            squash = true;
           }
-          branch = args[1];
-        } else if (args[1] === '--no-ff' || args[1] === '--ff') {
-          if (args[1] === '--no-ff') {
-            noFF = true;
-          }
-          branch = args[0];
         } else {
-          this.info('This demo only supports the --no-ff and --ff switches..');
+          this.info(`This demo only supports the following flags: ${validFlagsStr}`);
         }
       }
 
       this.transact(function() {
-        result = this.getRepoView().merge(branch, noFF);
+        result = this.getRepoView().merge(branch, noFF, squash);
 
         if (result === 'Fast-Forward') {
           this.info('You have performed a fast-forward merge.');

--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -257,6 +257,7 @@ function(_yargs, d3, demos) {
         this.info('`git fetch`')
         this.info('`git log`')
         this.info('`git merge`')
+        this.info('`git merge-base`')
         this.info('`git pull`')
         this.info('`git push`')
         this.info('`git rebase`')
@@ -697,6 +698,12 @@ function(_yargs, d3, demos) {
           )
         }
       })
+    },
+
+    merge_base: function(args) {
+      let [ref_a, ref_b] = args;
+      let merge_base = this.getRepoView().mergeBase(ref_a, ref_b);
+      this.info(merge_base ? merge_base.id : 'No common ancestor');
     },
 
     rebase: function(args) {

--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -160,6 +160,7 @@ function(_yargs, d3, demos) {
         var e = d3.event;
 
         switch (e.keyCode) {
+          // Enter
           case 13:
             if (this.value.trim() === '' || cBox.locked) {
               return;
@@ -172,6 +173,7 @@ function(_yargs, d3, demos) {
             this.value = '';
             e.stopImmediatePropagation();
             break;
+          // ArrowUp
           case 38:
             var previousCommand = cBox._commandHistory[cBox._currentCommand + 1];
             if (cBox._currentCommand === -1) {
@@ -185,6 +187,7 @@ function(_yargs, d3, demos) {
             }
             e.stopImmediatePropagation();
             break;
+          // ArrowDown
           case 40:
             var nextCommand = cBox._commandHistory[cBox._currentCommand - 1];
             if (typeof nextCommand === 'string') {

--- a/js/historyview.js
+++ b/js/historyview.js
@@ -302,8 +302,17 @@ define(['d3'], function() {
     }
   }
 
-  HistoryView.generateId = function() {
-    return Math.floor((1 + Math.random()) * 0x10000000).toString(16).substring(1);
+  // Ensure generated commit hashes are unique
+  HistoryView._usedIds = new Set();
+
+  HistoryView.generateId = function () {
+    let id;
+    do {
+      // 7 char hex string
+      id = Math.floor((1 + Math.random()) * 0x10000000).toString(16).substring(1);
+    } while (HistoryView._usedIds.has(id));
+    HistoryView._usedIds.add(id);
+    return id;
   };
 
   HistoryView.prototype = {

--- a/js/historyview.js
+++ b/js/historyview.js
@@ -385,7 +385,7 @@ define(['d3'], function() {
 
     /**
      * @method getCommit
-     * @param ref {String} the id or a tag name that refers to the commit
+     * @param ref {String, Object} the id or a tag name that refers to the commit. Commit objects are returned.
      * @return {Object} the commit datum object
      */
     getCommit: function getCommit(ref) {
@@ -1702,10 +1702,10 @@ define(['d3'], function() {
         this.flashProperty(commitsToCopy, 'rebased', function() {
           commitsToCopy.forEach(function(ref) {
             var oldCommit = this.getCommit(ref)
-            this.commit({rebased: true, rebaseSource: ref}, oldCommit.message)
-              this.addReflogEntry(
-                'HEAD', this.getCommit('HEAD').id, 'rebase: ' + (oldCommit.message || oldCommit.id)
-              )
+            this.commit({rebased: true, rebaseSource: ref}, oldCommit.message);
+            this.addReflogEntry(
+              'HEAD', this.getCommit('HEAD').id, 'rebase: ' + (oldCommit.message || oldCommit.id)
+            );
           }, this)
           var newHeadCommit = this.getCommit('HEAD')
           this.lock()

--- a/js/historyview.js
+++ b/js/historyview.js
@@ -1511,6 +1511,10 @@ define(['d3'], function() {
       let commit_a = typeof ref_a === 'string' ? this.getCommit(ref_a) : ref_a;
       let commit_b = typeof ref_b === 'string' ? this.getCommit(ref_b) : ref_b;
 
+      if (commit_a === commit_b) {
+        return commit_a;
+      }
+
       let ff_parent;
 
       let a_to_root = this.walkAncestors(commit_a, (commit) => {

--- a/js/historyview.js
+++ b/js/historyview.js
@@ -1577,7 +1577,7 @@ define(['d3'], function() {
       return base_commit;
     },
 
-    merge: function(ref, noFF) {
+    merge: function(ref, noFF, squash) {
       var mergeSource = this.getCommit(ref),
         mergeTarget = this.getCommit('HEAD');
       
@@ -1612,10 +1612,13 @@ define(['d3'], function() {
           parent2: mergeSource.id,
           isNoFFCommit: true
         }, 'Merge');
+      } else if (squash === true) {
+        
       } else if (this.isAncestorOf(mergeTarget.id, mergeSource.id)) {
         this.fastForward(mergeSource);
         return 'Fast-Forward';
       } else {
+        // No flags, and commit is not fast-forwardable, so create a merge commit
         this.commit({
           parent2: mergeSource.id
         }, 'Merge');


### PR DESCRIPTION
Hand waves over the fact that you normally need to "commit" after this, this creates a new commit of the "squashed" version of the commits from the target branch to the merge-base of the checked out branch.

We "flash" the commits we are about to squash, then create that new commit on the checked out point, also with a new color.

![merge-squash](https://github.com/visualizing-git/visualizing-git-actions/assets/84343478/f23e70ec-5290-4bbd-afb6-4f36f68a51d1)
